### PR TITLE
[ci] refs #19 - Bump version number to 0.0.2

### DIFF
--- a/LibskycoinNet/LibskycoinNet.csproj
+++ b/LibskycoinNet/LibskycoinNet.csproj
@@ -11,9 +11,9 @@
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
     <PackOnBuild>true</PackOnBuild>
     <PackageId>LibskycoinNet</PackageId>
-    <Version Condition=" '$(PackageVersion)' == '' ">0.0.1-local</Version>
+    <Version Condition=" '$(PackageVersion)' == '' ">0.0.2-local</Version>
     <Version Condition=" '$(PackageVersion)' != '' ">$(PackageVersion)</Version>
-    <PackageVersion Condition=" '$(PackageVersion)' == '' ">0.0.1-local</PackageVersion>
+    <PackageVersion Condition=" '$(PackageVersion)' == '' ">0.0.2-local</PackageVersion>
     <PackageVersion Condition=" '$(PackageVersion)' != '' ">$(PackageVersion)</PackageVersion>
     <Company>Skycoin</Company>
     <Authors>Maykel Arias - (stdevHan), Olemis Lang (olemis), Skycoin (skycoin)</Authors>


### PR DESCRIPTION
Fixes #19

Changes:
- New release target `0.0.2`

Does this change need to mentioned in CHANGELOG.md?

No

